### PR TITLE
Fix invalid style tag in HTML head

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,8 +11,6 @@
   <link href="https://unpkg.com/ionicons@7.1.0/dist/ionicons/ionicons.css" rel="stylesheet">
   <link href="styles.css" rel="stylesheet">
   <link href="tutorial.css" rel="stylesheet">
-
-  </style>
 </head>
 
 <body>


### PR DESCRIPTION
## Summary
- remove stray closing `</style>` tag from `index.html`

## Testing
- `node --check script.js`
- `npx --yes htmlhint index.html` *(fails: 403 Forbidden)*
- `tidy -errors -q index.html` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68967371e03883279954c26b3a382943